### PR TITLE
Fixed not terminated thread bug

### DIFF
--- a/src/main/game/MainMultiPlayerThread.java
+++ b/src/main/game/MainMultiPlayerThread.java
@@ -91,11 +91,7 @@ public class MainMultiPlayerThread extends Thread {
 				root.remove(graphics);
 				root.add(new StartMenu(player1, player2, root, highScore, args));
 				root.revalidate();
-				try {
-					join();
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-				}
+				running = false;
 			}
 		}
 	}

--- a/src/main/game/MainSinglePlayerThread.java
+++ b/src/main/game/MainSinglePlayerThread.java
@@ -88,11 +88,7 @@ public class MainSinglePlayerThread extends Thread {
 				root.remove(graphics);
 				root.add(new StartMenu(game, second, root, score, args));
 				root.revalidate();
-				try {
-					join();
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-				}
+				running = false;
 			}
 		}
 	}


### PR DESCRIPTION
Remove join() to terminated thread properly in run().
A new thread is created each time a new game starts.
Please check.